### PR TITLE
use get_latest_version_number in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,11 @@ from setuptools import find_packages, setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-
-with open(str(pathlib.Path(__file__).parent.absolute()) +
-          "/flitton_fib_py/version.py", "r") as fh:
-    version = fh.read().split("=")[1].replace("'", "")
-
+from get_latest_version import get_latest_version_number
 
 setup(
     name="flitton_fib_py",
-    version=version,
+    version=get_latest_version_number(),
     author="Maxwell Flitton",
     author_email="maxwell@gmail.com",
     description="Calculates a Fibonacci number",


### PR DESCRIPTION
Following along with your book, this command from Chapter 4 fails:

<img width="592" alt="image" src="https://github.com/maxwellflitton/flitton-fib-py/assets/9513841/22e33bf7-9379-4aa2-badd-2567e063b4e2">

It doesn't look like this change would impact anything like your CI/CD. Verified manually the change works via my fork...
